### PR TITLE
Add profile description

### DIFF
--- a/app/src/androidTest/java/com/github/palFinderTeam/palfinder/ProfileActivityTest.kt
+++ b/app/src/androidTest/java/com/github/palFinderTeam/palfinder/ProfileActivityTest.kt
@@ -1,7 +1,10 @@
 package com.github.palFinderTeam.palfinder
 
+import android.content.Context
 import android.content.Intent
+import android.content.res.Resources
 import android.icu.util.Calendar
+import androidx.test.InstrumentationRegistry
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onView
@@ -59,7 +62,7 @@ ProfileActivityTest {
         try{
             onView(ViewMatchers.withId(R.id.userProfileAboutTitle)).check(
                 ViewAssertions.matches(
-                    ViewMatchers.withText(ProfileActivity.NO_BIO_WARN)
+                    ViewMatchers.withText(getResourceString(R.string.no_desc))
                 )
             )
         }finally{
@@ -104,6 +107,12 @@ ProfileActivityTest {
         }finally{
             scenario.close()
         }
+    }
+
+
+    private fun getResourceString(id: Int): String? {
+        val targetContext: Context = InstrumentationRegistry.getTargetContext()
+        return targetContext.getResources().getString(id)
     }
 
 }

--- a/app/src/androidTest/java/com/github/palFinderTeam/palfinder/ProfileActivityTest.kt
+++ b/app/src/androidTest/java/com/github/palFinderTeam/palfinder/ProfileActivityTest.kt
@@ -27,7 +27,7 @@ ProfileActivityTest {
     @Before
     fun getProfile(){
         p = ProfileUser("gerussi", "Louca", "Gerussi", Calendar.getInstance(), ImageInstance("icons/cat.png"))
-        pImgHttps = ProfileUser("gerussi", "Louca", "Gerussi", Calendar.getInstance(), ImageInstance("https://fail"))
+        pImgHttps = ProfileUser("gerussi", "Louca", "Gerussi", Calendar.getInstance(), ImageInstance("https://fail"), "Hello world I am cat")
     }
 
     @Test
@@ -43,6 +43,40 @@ ProfileActivityTest {
             onView(ViewMatchers.withId(R.id.userProfileName)).check(
                 ViewAssertions.matches(
                     ViewMatchers.withText(p.fullName())
+                )
+            )
+        }finally{
+            scenario.close()
+        }
+    }
+
+    @Test
+    fun userHasNoBioDisplaysTitleDifferently(){
+        val intent = Intent(ApplicationProvider.getApplicationContext(), ProfileActivity::class.java)
+            .apply{ putExtra(DUMMY_USER, p as Serializable) }
+        // Launch activity
+        val scenario = ActivityScenario.launch<GreetingActivity>(intent)
+        try{
+            onView(ViewMatchers.withId(R.id.userProfileAboutTitle)).check(
+                ViewAssertions.matches(
+                    ViewMatchers.withText(ProfileActivity.NO_BIO_WARN)
+                )
+            )
+        }finally{
+            scenario.close()
+        }
+    }
+
+    @Test
+    fun userWithBioDisplaysShortBioEntirely(){
+        val intent = Intent(ApplicationProvider.getApplicationContext(), ProfileActivity::class.java)
+            .apply{ putExtra(DUMMY_USER, pImgHttps as Serializable) }
+        // Launch activity
+        val scenario = ActivityScenario.launch<GreetingActivity>(intent)
+        try{
+            onView(ViewMatchers.withId(R.id.userProfileDescription)).check(
+                ViewAssertions.matches(
+                    ViewMatchers.withText("Hello world I am cat")
                 )
             )
         }finally{

--- a/app/src/main/java/com/github/palFinderTeam/palfinder/MainActivity.kt
+++ b/app/src/main/java/com/github/palFinderTeam/palfinder/MainActivity.kt
@@ -31,6 +31,7 @@ class MainActivity : AppCompatActivity() {
 
     private companion object {
         private const val TAG = "MainActivity"
+        private const val PROFILE_DESC = "Hello this is the Cat, but you can call me Kitty. I like to lay around and do nothing. Also you can see that my profile picture looks cure but in real life I am a real biach. Enjoy!"
     }
 
     private lateinit var auth: FirebaseAuth
@@ -90,7 +91,7 @@ class MainActivity : AppCompatActivity() {
         joinDate.set(2022, 2, 1, 14, 1, 0)
         val pfp = ImageInstance("icons/cat.png")
         val intent = Intent(this, ProfileActivity::class.java).apply {
-            putExtra(DUMMY_USER, ProfileUser("theCat", "Epic", "Cat", joinDate, pfp) as Serializable)
+            putExtra(DUMMY_USER, ProfileUser("theCat", "Epic", "Cat", joinDate, pfp, PROFILE_DESC) as Serializable)
         }
         startActivity(intent)
     }

--- a/app/src/main/java/com/github/palFinderTeam/palfinder/ProfileActivity.kt
+++ b/app/src/main/java/com/github/palFinderTeam/palfinder/ProfileActivity.kt
@@ -1,11 +1,16 @@
 package com.github.palFinderTeam.palfinder
 
+import android.content.Context
+import android.content.res.Resources
 import android.os.Bundle
+import android.provider.Settings
+import android.provider.Settings.Global.getString
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
 import com.github.palFinderTeam.palfinder.profile.ProfileUser
 import kotlinx.coroutines.launch
+import java.util.logging.Logger.global
 
 /**
  * When creating the profile page, the username (which is unique) will
@@ -16,7 +21,6 @@ class ProfileActivity : AppCompatActivity() {
 
     companion object{
         const val EMPTY_FIELD = ""
-        const val NO_BIO_WARN = "No bio provided..."
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -39,7 +43,7 @@ class ProfileActivity : AppCompatActivity() {
 
     private fun injectBio(bio: String) {
         if (bio == EMPTY_FIELD) {
-            findViewById<TextView>(R.id.userProfileAboutTitle).text = NO_BIO_WARN
+            findViewById<TextView>(R.id.userProfileAboutTitle).text = this.resources.getString(R.string.no_desc)
             findViewById<TextView>(R.id.userProfileDescription).text = EMPTY_FIELD
         } else {
             findViewById<TextView>(R.id.userProfileDescription).text = bio

--- a/app/src/main/java/com/github/palFinderTeam/palfinder/ProfileActivity.kt
+++ b/app/src/main/java/com/github/palFinderTeam/palfinder/ProfileActivity.kt
@@ -1,8 +1,6 @@
 package com.github.palFinderTeam.palfinder
 
-import android.media.Image
 import android.os.Bundle
-import android.widget.ImageView
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
@@ -16,6 +14,11 @@ import kotlinx.coroutines.launch
  */
 class ProfileActivity : AppCompatActivity() {
 
+    companion object{
+        const val EMPTY_FIELD = ""
+        const val NO_BIO_WARN = "No bio provided..."
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_profile)
@@ -24,12 +27,24 @@ class ProfileActivity : AppCompatActivity() {
     }
 
     private fun injectUserInfo(user: ProfileUser) {
-        findViewById<TextView>(R.id.userProfileName).apply { text = user.fullName() }
-        findViewById<TextView>(R.id.userProfileUsername).apply { text = user.atUsername() }
+        findViewById<TextView>(R.id.userProfileName).text = user.fullName()
+        findViewById<TextView>(R.id.userProfileUsername).text = user.atUsername()
         findViewById<TextView>(R.id.userProfileJoinDate).apply { text = user.prettyJoinTime() }
+        injectBio(user.description)
         lifecycleScope.launch {
             user.pfp.loadImageInto(findViewById(R.id.userProfileImage))
         }
     }
+
+
+    private fun injectBio(bio: String) {
+        if (bio == EMPTY_FIELD) {
+            findViewById<TextView>(R.id.userProfileAboutTitle).text = NO_BIO_WARN
+            findViewById<TextView>(R.id.userProfileDescription).text = EMPTY_FIELD
+        } else {
+            findViewById<TextView>(R.id.userProfileDescription).text = bio
+        }
+    }
+
 
 }

--- a/app/src/main/java/com/github/palFinderTeam/palfinder/profile/ProfileUser.kt
+++ b/app/src/main/java/com/github/palFinderTeam/palfinder/profile/ProfileUser.kt
@@ -14,7 +14,8 @@ data class ProfileUser(
     val name: String,
     val surname: String,
     val joinDate: Calendar,
-    val pfp: ImageInstance
+    val pfp: ImageInstance,
+    val description: String = ""
 ) : Serializable {
 
     companion object{

--- a/app/src/main/res/layout/activity_profile.xml
+++ b/app/src/main/res/layout/activity_profile.xml
@@ -3,43 +3,22 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@color/theme_dark">
+    android:layout_height="wrap_content"
+    android:background="@color/theme_bright"
+    android:padding="30dp">
 
-    <View
-        android:id="@+id/userProfileTop"
-        android:layout_width="0dp"
-        android:layout_height="300dp"
-        android:background="#EFEBE2"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
-    <View
-        android:id="@+id/userProfileUpTabCircle"
-        android:layout_width="0dp"
-        android:layout_height="36dp"
-        android:layout_marginTop="-18dp"
-        android:background="@drawable/circle_shape"
-        android:backgroundTint="@color/theme_bright"
-        android:scaleX="1.4"
-        app:layout_constraintEnd_toEndOf="@+id/userProfileTop"
-        app:layout_constraintStart_toStartOf="@+id/userProfileTop"
-        app:layout_constraintTop_toBottomOf="@+id/userProfileTop" />
 
     <com.google.android.material.imageview.ShapeableImageView
         android:id="@+id/userProfileImage"
         android:layout_width="160dp"
         android:layout_height="160dp"
 
-        android:layout_marginStart="35dp"
-        android:layout_marginTop="35dp"
         android:adjustViewBounds="true"
         android:background="@color/theme_primary"
         android:scaleType="fitCenter"
         android:src="@drawable/demo_pfp"
-        app:layout_constraintStart_toStartOf="@id/userProfileTop"
-        app:layout_constraintTop_toTopOf="@id/userProfileTop"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
         app:shapeAppearanceOverlay="@style/profileRoundEdge" />
 
     <TextView
@@ -86,6 +65,32 @@
         app:layout_constraintBottom_toBottomOf="@+id/userProfileUsername"
         app:layout_constraintStart_toEndOf="@+id/userProfileUsername"
         app:layout_constraintTop_toTopOf="@+id/userProfileUsername" />
+
+    <TextView
+        android:id="@+id/userProfileDescription"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="7dp"
+        android:ellipsize="end"
+        android:fontFamily="@font/fredoka_bold"
+        android:maxLines="2"
+        android:text="@string/placeholder_desc"
+        android:textSize="14sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="@+id/userProfileAboutTitle"
+        app:layout_constraintTop_toBottomOf="@+id/userProfileAboutTitle" />
+
+    <TextView
+        android:id="@+id/userProfileAboutTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="20dp"
+        android:alpha="0.5"
+        android:fontFamily="@font/fredoka_bold"
+        android:text="@string/desc_name"
+        app:layout_constraintStart_toStartOf="@+id/userProfileUsername"
+        app:layout_constraintTop_toBottomOf="@+id/userProfileUsername" />
 
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -60,6 +60,9 @@
     <string name="placeholder_name">someone</string>
     <string name="placeholder_username">\@username</string>
     <string name="placeholder_date">yyyy/mm/dd</string>
+    <string name="desc_name">— About me</string>
+    <string name="placeholder_desc">Hello, I am a placeholder description. I am long enough so that I break onto another line, hopefully, but if not then I will add some extra text.</string>
+    <string name="no_desc">No bio provided...</string>
 
     <string name="title_activity_login">LoginActivity</string>
     <string name="prompt_email">Email</string>

--- a/app/src/main/res/values/style.xml
+++ b/app/src/main/res/values/style.xml
@@ -5,4 +5,5 @@
         <item name="cornerSize">20dp</item>
         <item name="color">@color/theme_bright</item>
     </style>
+
 </resources>


### PR DESCRIPTION
**What**
In this pull request, I've added descriptions field for profiles, stored in the user class `description: String = ""` an empty string by default:

- User profile description and integration, if no bio provided write appropriate "No bio" message
- Revamped profile for better optimization