### PR TITLE
Fix meetup creation location.

### DIFF
--- a/app/src/androidTest/java/com/github/palFinderTeam/palfinder/meetups/activities/MeetupViewTest.kt
+++ b/app/src/androidTest/java/com/github/palFinderTeam/palfinder/meetups/activities/MeetupViewTest.kt
@@ -44,6 +44,7 @@ import com.github.palFinderTeam.palfinder.profile.UIMockProfileServiceModule
 import com.github.palFinderTeam.palfinder.utils.*
 import com.github.palFinderTeam.palfinder.utils.image.ImageInstance
 import com.github.palFinderTeam.palfinder.utils.time.TimeService
+import com.google.android.gms.maps.model.LatLng
 import com.google.android.material.chip.Chip
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
@@ -146,7 +147,6 @@ class MeetupViewTest {
             null,
             null
         )
-
 
         UiThreadStatement.runOnUiThread {
             navController = TestNavHostController(getApplicationContext())
@@ -303,9 +303,12 @@ class MeetupViewTest {
                 Pair("MeetUpId", null)
             ), navHostController = navController
         )
-        scenario.use {
+        scenario!!.use {
             Intents.init()
 
+            scenario.onHiltFragment<MeetUpCreation> {
+                it.viewModel.setLatLng(LatLng(0.0,0.0))
+            }
             onView(withId(R.id.et_EventName)).perform(typeText("Meetup name"), click())
             onView(withId(R.id.et_Description)).perform(typeText("Meetup description"), click())
             closeSoftKeyboard()
@@ -391,8 +394,12 @@ class MeetupViewTest {
                 Pair("MeetUpId", null)
             ), navHostController = navController
         )
-        scenario.use {
+        scenario!!.use {
             Intents.init()
+
+            scenario.onHiltFragment<MeetUpCreation> {
+                it.viewModel.setLatLng(LatLng(0.0,0.0))
+            }
 
             onView(withId(R.id.et_EventName)).perform(typeText("Meetup name"), click())
             onView(withId(R.id.et_Description)).perform(typeText("Meetup description"), click())
@@ -432,9 +439,12 @@ class MeetupViewTest {
                 Pair("MeetUpId", null)
             ), navHostController = navController
         )
-        scenario.use {
+        scenario!!.use {
             Intents.init()
 
+            scenario.onHiltFragment<MeetUpCreation> {
+                it.viewModel.setLatLng(LatLng(0.0,0.0))
+            }
             onView(withId(R.id.et_EventName)).perform(typeText("Meetup name"), click())
             onView(withId(R.id.et_Description)).perform(typeText("Meetup description"), click())
             closeSoftKeyboard()

--- a/app/src/main/java/com/github/palFinderTeam/palfinder/meetups/activities/MeetUpCreation.kt
+++ b/app/src/main/java/com/github/palFinderTeam/palfinder/meetups/activities/MeetUpCreation.kt
@@ -219,6 +219,10 @@ class MeetUpCreation : Fragment(R.layout.activity_meet_up_creation_new), IconDia
                 }
             }
         }
+        viewModel.location.observeOnce(this) {
+            // We convert for visual consistency.
+            setTextView(R.id.tv_location, it.toLatLng().toString())
+        }
 
         viewModel.canEditStartDate.observe(viewLifecycleOwner) {
             startDateField.isClickable = it
@@ -279,8 +283,8 @@ class MeetUpCreation : Fragment(R.layout.activity_meet_up_creation_new), IconDia
     /**
      * Check Name and Description are present
      */
-    private fun checkFieldValid(name: String, description: String): Boolean {
-        if (name == "" || description == "") {
+    private fun checkFieldValid(name: String, description: String, location: Location?): Boolean {
+        if (name == "" || description == "" || location == null) {
             showMessage(
                 R.string.meetup_creation_missing_name_desc,
                 R.string.meetup_creation_missing_name_desc_title
@@ -294,7 +298,8 @@ class MeetUpCreation : Fragment(R.layout.activity_meet_up_creation_new), IconDia
         // Check field validity
         val name = nameEditText.text.toString()
         val description = descriptionEditText.text.toString()
-        if (!checkFieldValid(name, description)) return
+        val location = viewModel.location.value
+        if (!checkFieldValid(name, description, location)) return
 
         // Listen on DB response to move forward.
         viewModel.sendSuccess.observe(viewLifecycleOwner) { isSuccessFull ->

--- a/app/src/main/java/com/github/palFinderTeam/palfinder/meetups/activities/MeetUpCreationViewModel.kt
+++ b/app/src/main/java/com/github/palFinderTeam/palfinder/meetups/activities/MeetUpCreationViewModel.kt
@@ -104,7 +104,6 @@ class MeetUpCreationViewModel @Inject constructor(
         _description.value = ""
         _tags.value = emptySet()
         _participantsId.value = listOf(profileService.getLoggedInUserID()!!)
-        _location.value = Location(0.0, 0.0)
         _criterionAge.value = Pair(13, 66)
     }
 
@@ -322,14 +321,6 @@ class MeetUpCreationViewModel @Inject constructor(
                 _tags.value = tags.plus(tag)
                 true
             }
-        }
-    }
-
-    fun getLatLng(): LatLng? {
-        return if (location.value != null) {
-            LatLng(location.value!!.latitude, location.value!!.longitude)
-        } else {
-            null
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -62,7 +62,7 @@
     <string name="list_sort_by_capacity">Sort by Cap.</string>
     <string name="list_sort_by_location">Sort by Dist.</string>
     <string name="list_sort_menu">Sort</string>
-    <string name="meetup_creation_missing_name_desc">Please add an Event Name and an Event Description</string>
+    <string name="meetup_creation_missing_name_desc">Please add an Event Name, an Event Description and a location</string>
     <string name="meetup_creation_missing_name_desc_title">Missing Data</string>
 
 


### PR DESCRIPTION
## What ?
Fix meetup location when creating a new meetup.
It was always set by default to 0 0, which is weird, now it is not
defined at first, and it is considered as a mandatory field. (like name
and description).
Also now when editing an existing meetup the location will be displayed.