### PR TITLE
Fix the image in recyclerview bug.

### DIFF
--- a/app/src/main/java/com/github/palFinderTeam/palfinder/meetups/MeetupListRootAdapter.kt
+++ b/app/src/main/java/com/github/palFinderTeam/palfinder/meetups/MeetupListRootAdapter.kt
@@ -91,9 +91,6 @@ open class MeetupListRootAdapter(
             CoroutineScope(Dispatchers.Main).launch {
                 currentDataSet[position].iconImage?.let {
                     it.loadImageInto(meetupPicture, context)
-                    // Don't ask me why it works, but you have manually reset the imageView to
-                    // visible otherwise it randomly disappear.
-                    meetupPicture.visibility = View.VISIBLE
                 }
             }
         } else {

--- a/app/src/main/java/com/github/palFinderTeam/palfinder/profile/ProfileAdapter.kt
+++ b/app/src/main/java/com/github/palFinderTeam/palfinder/profile/ProfileAdapter.kt
@@ -101,7 +101,6 @@ class ProfileAdapter(
                 holder.pic,
                 context
             )
-            holder.pic.visibility = View.VISIBLE
         }
     }
 


### PR DESCRIPTION
## What ?
Images would randomly disappear in a list.
Basically you just have to reset the visibility of the image view to VISIBLE, because the recycler view would randomly put it to non visible, actually that is probably due to the fact that the meetups without images would put the visibility to INVISIBLE, but not the opposite, and since the views are recycled, this explains everything.