### PR TITLE
Hide certain options when not needed

### DIFF
--- a/app/src/androidTest/java/com/github/palFinderTeam/palfinder/meetups/activities/MeetupListTest.kt
+++ b/app/src/androidTest/java/com/github/palFinderTeam/palfinder/meetups/activities/MeetupListTest.kt
@@ -22,6 +22,7 @@ import androidx.test.espresso.contrib.PickerActions
 import androidx.test.espresso.intent.Intents.*
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
 import androidx.test.espresso.matcher.BoundedMatcher
+import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.internal.runner.junit4.statement.UiThreadStatement.runOnUiThread
 import com.github.palFinderTeam.palfinder.R
@@ -537,6 +538,31 @@ class MeetUpListTest {
                 )
                     .check(matches(anyOf(joinedMeetUps)))
             }
+        }
+    }
+
+    @Test
+    fun showJoinedHideCertainOptions() = runTest {
+        meetUpList.forEach { meetUpRepository.create(it) }
+
+        val scenario = launchFragmentInHiltContainer<MeetupListFragment>(Bundle().apply {
+            putSerializable("ShowParam", ShowParam.ALL)
+        }, navHostController = navController)
+
+        scenario!!.use {
+            onView(withId(R.id.select_filters)).perform(click())
+            onView(withId(R.id.joinedButton)).perform(click())
+            Espresso.pressBack()
+
+            onView(withId(R.id.distance_slider)).check(matches(withEffectiveVisibility(Visibility.GONE)))
+            onView(withId(R.id.search_place)).check(matches(withEffectiveVisibility(Visibility.GONE)))
+
+            onView(withId(R.id.select_filters)).perform(click())
+            onView(withId(R.id.button_all)).perform(click())
+            Espresso.pressBack()
+
+            onView(withId(R.id.distance_slider)).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+            onView(withId(R.id.search_place)).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
         }
     }
 

--- a/app/src/main/java/com/github/palFinderTeam/palfinder/meetups/activities/MapListViewModel.kt
+++ b/app/src/main/java/com/github/palFinderTeam/palfinder/meetups/activities/MapListViewModel.kt
@@ -1,6 +1,7 @@
 package com.github.palFinderTeam.palfinder.meetups.activities
 
 import android.Manifest
+import android.annotation.SuppressLint
 import android.app.Application
 import android.content.pm.PackageManager
 import android.icu.util.Calendar
@@ -24,6 +25,7 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 
+@SuppressLint("MissingPermission")
 @ExperimentalCoroutinesApi
 @HiltViewModel
 /**
@@ -81,7 +83,8 @@ class MapListViewModel @Inject constructor(
     private val _searchLocation = MutableLiveData(START_LOCATION)
     val searchLocation: LiveData<Location> = _searchLocation
     val searchRadius: LiveData<Double> = _searchRadius
-    var showParam: ShowParam = ShowParam.ALL
+    private val _showParam = MutableLiveData(ShowParam.ALL)
+    val showParam: LiveData<ShowParam> = _showParam
     private var showOnlyAvailableInTime = true
     private var filterBlockedUserMeetups = true
 
@@ -132,7 +135,7 @@ class MapListViewModel @Inject constructor(
             _searchRadius.value = it
         }
         showParam?.let {
-            this.showParam = it
+            _showParam.value = it
         }
         showOnlyAvailable?.let {
             showOnlyAvailableInTime = it
@@ -165,7 +168,7 @@ class MapListViewModel @Inject constructor(
             (!forceFetch)
             && (location == null || searchLocation.value == location)
             && (radiusInKm == null || searchRadius.value == radiusInKm)
-            && (this.showParam == showParam)
+            && (this.showParam.value == showParam)
             && (showOnlyAvailable == null || showOnlyAvailableInTime == showOnlyAvailable)
             && (filterBlockedMeetups == null || filterBlockedMeetups == filterBlockedUserMeetups)
         ) {
@@ -188,12 +191,12 @@ class MapListViewModel @Inject constructor(
      * call it by themself.
      */
     fun fetchMeetUps() {
-        when (showParam) {
+        when (showParam.value) {
             ShowParam.ONLY_JOINED -> fetchUserMeetUps()
             else -> getMeetupAroundLocation(
                 searchLocation.value!!,
                 searchRadius.value ?: INITIAL_RADIUS,
-                showParam
+                showParam.value!!
             )
         }
     }

--- a/app/src/main/java/com/github/palFinderTeam/palfinder/meetups/activities/MeetupListFragment.kt
+++ b/app/src/main/java/com/github/palFinderTeam/palfinder/meetups/activities/MeetupListFragment.kt
@@ -22,6 +22,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.github.palFinderTeam.palfinder.R
 import com.github.palFinderTeam.palfinder.meetups.MeetUp
 import com.github.palFinderTeam.palfinder.meetups.MeetupListAdapter
+import com.github.palFinderTeam.palfinder.meetups.activities.ShowParam.ONLY_JOINED
 import com.github.palFinderTeam.palfinder.meetups.fragments.CriterionsFragment
 import com.github.palFinderTeam.palfinder.meetups.fragments.MeetupFilterFragment
 import com.github.palFinderTeam.palfinder.tag.Category
@@ -55,6 +56,8 @@ class MeetupListFragment : Fragment() {
     private lateinit var radiusSlider: Slider
 
     private lateinit var filterSelectButton: Button
+
+    private lateinit var searchMapButton: ImageButton
 
 
     //viewModel to fetch the meetups and handle the localisation
@@ -92,31 +95,24 @@ class MeetupListFragment : Fragment() {
             viewModel.setSearchParamAndFetch(radiusInKm = value.toDouble())
         }
 
-        //radioGroup to choose between the different options about followers
-        /*
-        val followerOptions: RadioGroup = view.findViewById(R.id.follower_options_group)
-        when (args.showParam) {
-            ShowParam.ALL -> view.findViewById<RadioButton>(R.id.button_all).isChecked = true
-            ShowParam.ONLY_JOINED -> view.findViewById<RadioButton>(R.id.joinedButton).isChecked = true
-            ShowParam.PAL_PARTCIPATING -> view.findViewById<RadioButton>(R.id.participate_button).isChecked = true
-            ShowParam.PAL_CREATOR -> view.findViewById<RadioButton>(R.id.created_button).isChecked = true
-        }
-        followerOptions.setOnCheckedChangeListener { _, checkedId ->
-            val radio: RadioButton = view.findViewById(checkedId)
-            when (followerOptions.indexOfChild(radio)) {
-                0 -> viewModel.setSearchParamAndFetch(showParam = ShowParam.ALL)
-                1 -> viewModel.setSearchParamAndFetch(showParam = ShowParam.PAL_PARTICIPATING)
-                2 -> viewModel.setSearchParamAndFetch(showParam = ShowParam.PAL_CREATOR)
-                3 -> viewModel.setSearchParamAndFetch(showParam = ShowParam.ONLY_JOINED)
+        searchMapButton = view.findViewById(R.id.search_place)
+        searchMapButton.setOnClickListener { searchOnMap() }
+
+        viewModel.showParam.observe(requireActivity()) {
+            val visibility = if (it == ONLY_JOINED) {
+                View.GONE
+            } else {
+                View.VISIBLE
             }
+            radiusSlider.visibility = visibility
+            searchMapButton.visibility = visibility
         }
-         */
 
 
         //generate a new adapter for the recyclerView every time the meetUps dataset changes
-        viewModel.listOfMeetUpResponse.observe(requireActivity()) { it ->
-            if (it is Response.Success && viewModel.searchLocation.value != null) {
-                val meetups = it.data
+        viewModel.listOfMeetUpResponse.observe(requireActivity()) { meetupResponse ->
+            if (meetupResponse is Response.Success && viewModel.searchLocation.value != null) {
+                val meetups = meetupResponse.data
                 adapter = MeetupListAdapter(
                     meetups, meetups.toMutableList(),
                     SearchedFilter(
@@ -158,7 +154,6 @@ class MeetupListFragment : Fragment() {
         }
 
         view.findViewById<Button>(R.id.sort_list).setOnClickListener { showMenu(it) }
-        view.findViewById<ImageButton>(R.id.search_place).setOnClickListener { searchOnMap() }
 
         viewModel.setSearchParamAndFetch(showParam = args.showParam, showOnlyAvailable = true, forceFetch = true)
     }

--- a/app/src/main/java/com/github/palFinderTeam/palfinder/meetups/activities/ShowParam.kt
+++ b/app/src/main/java/com/github/palFinderTeam/palfinder/meetups/activities/ShowParam.kt
@@ -1,7 +1,5 @@
 package com.github.palFinderTeam.palfinder.meetups.activities
 
-import com.github.palFinderTeam.palfinder.utils.Gender
-
 /**
  * simple enum class used to pass parameters to the meetup fetch and retrieve only those matching conditions
  */

--- a/app/src/main/java/com/github/palFinderTeam/palfinder/meetups/fragments/MeetupFilterFragment.kt
+++ b/app/src/main/java/com/github/palFinderTeam/palfinder/meetups/fragments/MeetupFilterFragment.kt
@@ -44,7 +44,7 @@ class MeetupFilterFragment(val viewModel: MapListViewModel) : DialogFragment() {
         filterGroup = v.findViewById(R.id.follower_options_group)
 
         // Check currently selected option
-        when (viewModel.showParam) {
+        when (viewModel.showParam.value!!) {
             ShowParam.ALL -> filterGroup.check(R.id.button_all)
             ShowParam.PAL_PARTICIPATING -> filterGroup.check(R.id.participate_button)
             ShowParam.PAL_CREATOR -> filterGroup.check(R.id.created_button)


### PR DESCRIPTION
## What?
When we are in the meetup list and select showOnlyJoined filtrer, it does not make sense to show options such as radius slider and select on map, since it shows all meetups regardless of their locations.
This PR fix this, now when this option is selected the slider and map button will disappear and reappear when the option is deselected.